### PR TITLE
Host react app in GitHub pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,7 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main' && success()
+        run: npm run deploy

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "codespaces-react",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://DanAmner.github.io/react-piano-notes",
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
@@ -21,7 +22,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "test": "vitest"
+    "test": "vitest",
+    "deploy": "npm run build && gh-pages -d build"
   },
   "eslintConfig": {
     "extends": [
@@ -54,7 +56,8 @@
     "jsdom": "^25.0.1",
     "vite": "^5.4.10",
     "vitest": "^2.1.4",
-    "@testing-library/jest-dom": "^6.6.3"
+    "@testing-library/jest-dom": "^6.6.3",
+    "gh-pages": "^5.0.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Fixes #40

Add deployment to GitHub Pages in GitHub Actions workflow.

* Add `homepage` field in `package.json` with the URL of the GitHub Pages site.
* Add `gh-pages` package as a development dependency in `package.json`.
* Add `deploy` script in `package.json` to build the application and deploy it to GitHub Pages.
* Add a step in `.github/workflows/ci.yml` to deploy to GitHub Pages after the tests pass, only on the `main` branch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DanAmner/react-piano-notes/pull/41?shareId=39d61961-87ee-4a55-a03e-758efc6cc794).